### PR TITLE
Added a method to retrieve an Oauth2 Access Token using Google Play Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Install the aerogear-oauth2-cordova plugin by executing:
 
 ### Sample example
 
-In `wwww/js/index.js` file, to start the OAuth2 dance as soon as `onDeviceReady` event is fired, add the foloowing snippet:
+In `wwww/js/index.js` file, to start the OAuth2 dance as soon as `onDeviceReady` event is fired, add the following snippet:
 
 ```javascript
   onDeviceReady: function () {
@@ -90,6 +90,24 @@ In `wwww/js/index.js` file, to start the OAuth2 dance as soon as `onDeviceReady`
         alert(err.error);
       });
   },
+```
+
+### Google Play Services
+On Android you can use Google Play Services to retrieve an Oauth2 token using on of the device's authorized accounts.
+To make the Google Play Services available to your application, be sure to add the `com.google.playservices` cordova plugin to your project.
+Then request an Oauth2 token using Google Play Services as in this example:
+```javascript
+   oauth2.requestAccessUsingPlayServices({
+        scopes: 'openid',
+        accountTypes: 'com.google'
+     })
+     .then( function( accessToken ){
+        ...
+     })
+     .catch( function( error ) {
+        // an error happened
+     });
+   });
 ```
 
 ### Facebook iOS

--- a/plugin.xml
+++ b/plugin.xml
@@ -17,7 +17,6 @@
 
   <platform name="android">
     <dependency id="org.jboss.aerogear.cordova.android.reflect" url="https://github.com/edewit/aerogear-reflect-cordova.git"/>
-        compile 'com.google.android.gms:play-services:4.0.30@aar'
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="OAuth2Plugin">
         <param name="android-package" value="org.jboss.aerogear.cordova.oauth2.OAuth2Plugin"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -17,6 +17,7 @@
 
   <platform name="android">
     <dependency id="org.jboss.aerogear.cordova.android.reflect" url="https://github.com/edewit/aerogear-reflect-cordova.git"/>
+        compile 'com.google.android.gms:play-services:4.0.30@aar'
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="OAuth2Plugin">
         <param name="android-package" value="org.jboss.aerogear.cordova.oauth2.OAuth2Plugin"/>
@@ -25,7 +26,11 @@
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
       <service android:name="org.jboss.aerogear.android.authorization.oauth2.OAuth2AuthzService"/>
     </config-file>
+    <config-file target="AndroidManifest.xml" parent="/manifest/application">
+      <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
+    </config-file>
     <source-file src="src/android/OAuth2Plugin.java" target-dir="src/org/jboss/aerogear/cordova/oauth2/"/>
+    <source-file src="src/android/OauthGoogleServicesIntentHelper.java" target-dir="src/org/jboss/aerogear/cordova/oauth2/"/>
     <resource-file src="src/android/res/layout/oauth_web_view.xml" target="res/layout/oauth_web_view.xml" />
     <resource-file src="src/android/res/values/styles.xml" target="res/values/styles.xml" />
     <source-file src="src/android/libs/src/org/jboss/aerogear/android/authorization/AuthorizationConfiguration.java" target-dir="src/org/jboss/aerogear/android/authorization/"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -25,9 +25,6 @@
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
       <service android:name="org.jboss.aerogear.android.authorization.oauth2.OAuth2AuthzService"/>
     </config-file>
-    <config-file target="AndroidManifest.xml" parent="/manifest/application">
-      <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
-    </config-file>
     <source-file src="src/android/OAuth2Plugin.java" target-dir="src/org/jboss/aerogear/cordova/oauth2/"/>
     <source-file src="src/android/OauthGoogleServicesIntentHelper.java" target-dir="src/org/jboss/aerogear/cordova/oauth2/"/>
     <resource-file src="src/android/res/layout/oauth_web_view.xml" target="res/layout/oauth_web_view.xml" />

--- a/src/android/OAuth2Plugin.java
+++ b/src/android/OAuth2Plugin.java
@@ -120,8 +120,12 @@ public class OAuth2Plugin extends BasePlugin {
 
   public boolean requestAccessUsingPlayServices(JSONObject data, CallbackContext callbackContext) throws JSONException {
     cordova.setActivityResultCallback(this);
-    intentHelper = new OauthGoogleServicesIntentHelper(cordova, callbackContext);
-    intentHelper.triggerIntent(data);
+    if (OauthGoogleServicesIntentHelper.available) {
+      intentHelper = new OauthGoogleServicesIntentHelper(cordova, callbackContext);
+      intentHelper.triggerIntent(data);
+    } else {
+      callbackContext.error("Google Play Services is not available");
+    }
     return true;
   }
 

--- a/src/android/OAuth2Plugin.java
+++ b/src/android/OAuth2Plugin.java
@@ -118,10 +118,10 @@ public class OAuth2Plugin extends BasePlugin {
     return true;
   }
 
-  public boolean requestAccessUsingPlayServices(String scopes, CallbackContext callbackContext) {
+  public boolean requestAccessUsingPlayServices(JSONObject data, CallbackContext callbackContext) throws JSONException {
     cordova.setActivityResultCallback(this);
     intentHelper = new OauthGoogleServicesIntentHelper(cordova, callbackContext);
-    intentHelper.triggerIntent(scopes);
+    intentHelper.triggerIntent(data);
     return true;
   }
 

--- a/src/android/OAuth2Plugin.java
+++ b/src/android/OAuth2Plugin.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.aerogear.cordova.oauth2;
 
+import android.content.Intent;
 import android.util.Log;
 import org.apache.cordova.CallbackContext;
 import org.jboss.aerogear.android.core.Callback;
@@ -35,6 +36,7 @@ import java.util.Arrays;
  */
 public class OAuth2Plugin extends BasePlugin {
   private static final String TAG = OAuth2Plugin.class.getSimpleName();
+  private OauthGoogleServicesIntentHelper intentHelper;
 
   public boolean add(JSONObject data, CallbackContext callbackContext) throws JSONException, MalformedURLException {
     Log.d(TAG, "add account");
@@ -114,5 +116,20 @@ public class OAuth2Plugin extends BasePlugin {
       }
     });
     return true;
+  }
+
+  public boolean requestAccessUsingPlayServices(String scopes, CallbackContext callbackContext) {
+    cordova.setActivityResultCallback(this);
+    intentHelper = new OauthGoogleServicesIntentHelper(cordova, callbackContext);
+    intentHelper.triggerIntent(scopes);
+    return true;
+  }
+
+  @Override
+  public void onActivityResult(int requestCode, int resultCode, final Intent data) {
+    if (intentHelper != null) {
+      intentHelper.onActivityResult(requestCode, resultCode, data);
+    }
+    super.onActivityResult(requestCode, resultCode, data);
   }
 }

--- a/src/android/OauthGoogleServicesIntentHelper.java
+++ b/src/android/OauthGoogleServicesIntentHelper.java
@@ -23,9 +23,10 @@ import android.content.Intent;
 import android.util.Log;
 import com.google.android.gms.auth.GoogleAuthUtil;
 import com.google.android.gms.auth.UserRecoverableAuthException;
-import com.google.android.gms.common.AccountPicker;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 public class OauthGoogleServicesIntentHelper {
   private static final String TAG = "OauthGoogleServices";
@@ -42,13 +43,17 @@ public class OauthGoogleServicesIntentHelper {
     this.callbackContext = callbackContext;
   }
 
-  public boolean triggerIntent(final String plainScopes) {
-    scopes = "oauth2:" + (plainScopes.isEmpty() ? PROFILE_SCOPE : plainScopes);
+  public boolean triggerIntent(final JSONObject data) throws JSONException {
+    scopes = "oauth2:" + ( data.has("scopes") ? data.getString("scopes") : PROFILE_SCOPE );
+
+    final String[] accountTypes = (data.has("accountTypes"))
+      ? data.getString("accountTypes").split("\\s")
+      : new String[]{GoogleAuthUtil.GOOGLE_ACCOUNT_TYPE};
+
     Runnable runnable = new Runnable() {
       public void run() {
         try {
-          Intent intent = AccountPicker.newChooseAccountIntent(null, null,
-                  new String[]{GoogleAuthUtil.GOOGLE_ACCOUNT_TYPE}, false, null, null, null, null);
+          Intent intent = AccountManager.newChooseAccountIntent(null, null, accountTypes, false, null, null, null, null);
           cordova.getActivity().startActivityForResult(intent, REQUEST_CODE_PICK_ACCOUNT);
         } catch (ActivityNotFoundException e) {
           Log.e(TAG, "Activity not found: " + e.toString());

--- a/src/android/OauthGoogleServicesIntentHelper.java
+++ b/src/android/OauthGoogleServicesIntentHelper.java
@@ -1,0 +1,118 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright Red Hat, Inc., and individual contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.cordova.oauth2;
+
+import android.accounts.AccountManager;
+import android.app.Activity;
+import android.content.ActivityNotFoundException;
+import android.content.Intent;
+import android.util.Log;
+import com.google.android.gms.auth.GoogleAuthUtil;
+import com.google.android.gms.auth.UserRecoverableAuthException;
+import com.google.android.gms.common.AccountPicker;
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaInterface;
+
+public class OauthGoogleServicesIntentHelper {
+  private static final String TAG = "OauthGoogleServices";
+  private static final int REQUEST_CODE_PICK_ACCOUNT = 1000;
+  private static final int REQUEST_AUTHORIZATION = 2;
+  private static final String KEY_AUTH_TOKEN = "authtoken";
+  private static final String PROFILE_SCOPE = "https://www.googleapis.com/auth/plus.me";
+  private String scopes;
+  private CallbackContext callbackContext;
+  public CordovaInterface cordova;
+
+  public OauthGoogleServicesIntentHelper(CordovaInterface cordova, CallbackContext callbackContext) {
+    this.cordova = cordova;
+    this.callbackContext = callbackContext;
+  }
+
+  public boolean triggerIntent(final String plainScopes) {
+    scopes = "oauth2:" + (plainScopes.isEmpty() ? PROFILE_SCOPE : plainScopes);
+    Runnable runnable = new Runnable() {
+      public void run() {
+        try {
+          Intent intent = AccountPicker.newChooseAccountIntent(null, null,
+                  new String[]{GoogleAuthUtil.GOOGLE_ACCOUNT_TYPE}, false, null, null, null, null);
+          cordova.getActivity().startActivityForResult(intent, REQUEST_CODE_PICK_ACCOUNT);
+        } catch (ActivityNotFoundException e) {
+          Log.e(TAG, "Activity not found: " + e.toString());
+          callbackContext.error("Plugin cannot find activity: " + e.toString());
+        } catch (Exception e) {
+          Log.e(TAG, "Exception: " + e.toString());
+          callbackContext.error("Plugin failed to get account: " + e.toString());
+        }
+      }
+
+      ;
+    };
+    cordova.getActivity().runOnUiThread(runnable);
+    return true;
+  }
+
+  public void onActivityResult(int requestCode, int resultCode, final Intent data) {
+    if (callbackContext != null) {
+      try {
+        if (requestCode == REQUEST_CODE_PICK_ACCOUNT) {
+          if (resultCode == Activity.RESULT_OK) {
+            String accountName = data.getStringExtra(AccountManager.KEY_ACCOUNT_NAME);
+            Log.i(TAG, "account:" + accountName);
+            getToken(accountName);
+          } else {
+            callbackContext.error("plugin failed to get account");
+          }
+        } else if (requestCode == REQUEST_AUTHORIZATION) {
+          if (resultCode == Activity.RESULT_OK) {
+            String token = data.getStringExtra(KEY_AUTH_TOKEN);
+            callbackContext.success(token);
+          } else {
+            callbackContext.error("plugin failed to get token");
+          }
+        } else {
+          Log.i(TAG, "Unhandled activityResult. requestCode: " + requestCode + " resultCode: " + resultCode);
+        }
+      } catch (Exception e) {
+        callbackContext.error("Plugin failed to get email: " + e.toString());
+        Log.e(TAG, "Exception: " + e.toString());
+      }
+    } else {
+      Log.d(TAG, "No callback to go to!");
+    }
+  }
+
+  private void getToken(final String accountName) {
+    Runnable runnable = new Runnable() {
+      public void run() {
+        String token;
+        try {
+          Log.e(TAG, "Retrieving token for: " + accountName);
+          Log.e(TAG, "with scope(s): " + scopes);
+          token = GoogleAuthUtil.getToken(cordova.getActivity(), accountName, scopes);
+          callbackContext.success(token);
+        } catch (UserRecoverableAuthException userRecoverableException) {
+          Log.e(TAG, "UserRecoverableAuthException: Attempting recovery...");
+          cordova.getActivity().startActivityForResult(userRecoverableException.getIntent(), REQUEST_AUTHORIZATION);
+        } catch (Exception e) {
+          Log.i(TAG, "error" + e.getMessage());
+          callbackContext.error("plugin failed to get token: " + e.getMessage());
+        }
+      }
+    };
+    cordova.getThreadPool().execute(runnable);
+  }
+}

--- a/src/android/OauthGoogleServicesIntentHelper.java
+++ b/src/android/OauthGoogleServicesIntentHelper.java
@@ -133,8 +133,8 @@ public class OauthGoogleServicesIntentHelper {
       public void run() {
         String token;
         try {
-          Log.e(TAG, "Retrieving token for: " + accountName);
-          Log.e(TAG, "with scope(s): " + scopes);
+          Log.i(TAG, "Retrieving token for: " + accountName);
+          Log.i(TAG, "with scope(s): " + scopes);
           token = (String) METHOD_getToken.invoke(null, cordova.getActivity(), accountName, scopes);
           callbackContext.success(token);
         } catch (InvocationTargetException ite) {

--- a/www/oauth2.js
+++ b/www/oauth2.js
@@ -174,4 +174,38 @@ OAuth2.prototype.requestAccess = function (accountId) {
   });
 }
 
+/**
+  Use Google Play Services to request an access token using one of the device's authorized accounts.
+
+  @param {String} scopes - comma separated list of "scopes" you want access to.  Defaults to the "https://www.googleapis.com/auth/plus.me" scope.
+  @returns {Object} The ES6 promise (accessToken as a response parameter; if an error is returned)
+  @example
+  oauth2.requestAccessUsingPlayServices('openid)
+     .then( function( accessToken ){
+        ...
+     })
+     .catch( function( error ) {
+        // an error happened
+     });
+   });
+ */
+OAuth2.prototype.requestAccessUsingPlayServices = function(scopes) {
+    var success, error;
+
+    return new Promise(function (resolve, reject) {
+        error = function (error) {
+            reject({
+                error: error
+            });
+        };
+
+        success = function (result) {
+            resolve(result);
+        };
+
+        var args = scopes ? [scopes] : [''];
+        cordova.exec(success, error, 'OAuth2Plugin', 'requestAccessUsingPlayServices', args);
+    });
+}
+
 module.exports = new OAuth2();

--- a/www/oauth2.js
+++ b/www/oauth2.js
@@ -177,10 +177,15 @@ OAuth2.prototype.requestAccess = function (accountId) {
 /**
   Use Google Play Services to request an access token using one of the device's authorized accounts.
 
-  @param {String} scopes - comma separated list of "scopes" you want access to.  Defaults to the "https://www.googleapis.com/auth/plus.me" scope.
+  @status Experimental
+  @param {String} settings.scopes - comma separated list of "scopes" you want access to.  Defaults to the "https://www.googleapis.com/auth/plus.me" scope.
+  @param {String} settings.accountTypes - space-separated list of account types used to filter the list of accounts. The access token will be requested for the account selected from this list. eg. "com.google"
   @returns {Object} The ES6 promise (accessToken as a response parameter; if an error is returned)
   @example
-  oauth2.requestAccessUsingPlayServices('openid)
+  oauth2.requestAccessUsingPlayServices({
+        scopes: 'openid',
+        accountTypes: 'com.google'
+     })
      .then( function( accessToken ){
         ...
      })


### PR DESCRIPTION
This PR adds a method to the oauth2 cordova plugin enabling android applications to request an Oauth2 access token using one of the accounts authorized on the device.  The Google play Services API used is an Intent/Activity based one, and so we receive the access token via the cordova plugin's #onActivityResult method.

While this intent could have been initiated via an Aerogear authz module, the token still would have been returned via the #onActivityResult method, and the Authz module would have no knowledge of neither the token, nor the account used.  For these reasons the functionality was implemented solely within this plugin. 