### PR TITLE
Added org.jboss.aerogear.android.authz cordova plugin as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,45 +109,12 @@ Our iOS version is using a Swift library. Cordova is not yet fully supporting Sw
 3. set `Runpath Search Paths` to "$(inherited) @executable_path/Frameworks"
 ![search path](ios_step_3.png "search path")
 
-### Workaround for Android
-
-Our native Android library that the cordova plugin uses only supports gradle, luckily there is a build.gradle in the generated project. Add the following to this file, then use gradle to build as in `ANDROID_BUILD=gradle cordova build android`.  Alternatively you can execute `gradle installDebug` from the platforms/android directory.
-
-open platforms/android/build.gradle and under the `android` section add:
-
-```
-  repositories {
-    mavenCentral()
-  }
-
-  dependencies {
-    compile 'org.jboss.aerogear:aerogear-android-authz:2.0.0@aar'
-    compile 'org.jboss.aerogear:aerogear-android-core:2.0.0@aar'
-    compile 'org.jboss.aerogear:aerogear-android-pipe:2.0.0@aar'
-    compile 'org.jboss.aerogear:aerogear-android-store:2.0.0@aar'
-    compile 'com.google.code.gson:gson:1.7.2'
-  }
-
-```
-
-and add minSdkVersion and targetSdkVersion to defaultConfig, so that it looks like this:
-
-```
-  defaultConfig {
-    versionCode Integer.parseInt("" + getVersionCodeFromManifest() + "0")
-    minSdkVersion 16
-    targetSdkVersion 21
-  }
-
-```
-
 ## Todo
 
 This is a very early version:
 - remove Swift hack on xcodeproject
-- remove Android hack on gradle
 - expose refreshToken, revokeToken
-- 
+-
 ## Documentation
 
 For more details about the current release, please consult [our documentation](https://aerogear.org/docs/specs/aerogear-cordova/).

--- a/plugin.xml
+++ b/plugin.xml
@@ -17,31 +17,7 @@
 
   <platform name="android">
     <dependency id="org.jboss.aerogear.cordova.android.reflect" url="https://github.com/edewit/aerogear-reflect-cordova.git"/>
-    <info>
-      open platforms/android/build.gradle and under the `android` section add:
-
-      repositories {
-        mavenCentral()
-      }
-
-      dependencies {
-        compile 'org.jboss.aerogear:aerogear-android-authz:2.0.0@aar'
-        compile 'org.jboss.aerogear:aerogear-android-core:2.0.0@aar'
-        compile 'org.jboss.aerogear:aerogear-android-pipe:2.0.0@aar'
-        compile 'org.jboss.aerogear:aerogear-android-store:2.0.0@aar'
-        compile 'com.google.code.gson:gson:1.7.2'
-      }
-
-      and add minSdkVersion and targetSdkVersion to defaultConfig, like this:
-
-      defaultConfig {
-        versionCode Integer.parseInt("" + getVersionCodeFromManifest() + "0")
-        minSdkVersion 16
-        targetSdkVersion 21
-      }
-
-      you can not use `cordova build` but have to execute `gradle installDebug` from the platforms/android directory
-    </info>
+    <dependency id="org.jboss.aerogear.android.authz" url="https://github.com/bleathem/aerogear-authz-cordova.git"/>
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="OAuth2Plugin">
         <param name="android-package" value="org.jboss.aerogear.cordova.oauth2.OAuth2Plugin"/>


### PR DESCRIPTION
Used the org.jboss.aerogear.android.authz cordova plugin to provide the aerogear authz dependencies. This removes the requirement to build downstream projects with gradle